### PR TITLE
Fix : Game not saved when exit button is used.

### DIFF
--- a/linapple-pie/src/Applewin.cpp
+++ b/linapple-pie/src/Applewin.cpp
@@ -350,28 +350,11 @@ void EnterMessageLoop ()
 				ContinueExecution();
 				if (g_nAppMode != MODE_DEBUG)
 				{
-                    if (joyexitenable) 
-                        {
-                            CheckJoyExit();
-                            if  (joyquitevent) 
-				{ 
-                                if(g_fh)
-                                    {
-                                    fprintf(g_fh,"*** Logging ended\n\n");
-                                    fclose(g_fh);
-                                    }
-
-                                RiffFinishWriteFile();
-                                fclose(registry); 		//close conf file (linapple.conf by default)
-                                SDL_Quit();
-                                 // CURL routines
-                                curl_easy_cleanup(g_curl);
-                                curl_global_cleanup();
-                                printf("Linapple: successfully exited!\n");
-                                std::_Exit(0);
-                                }
-                        } 
-                                    
+					if (joyexitenable)
+					{
+						CheckJoyExit();
+						if (joyquitevent) return;
+					}
 					if (g_bFullSpeed)
 						ContinueExecution();
 				}


### PR DESCRIPTION
When using the option Save State Filename=1
- Exiting with [F10] saves the game
- Exiting with JoyExitButton0 + JoyExitButton1 does not save the game.

Exiting the program in EnterMessageLoop() skip Snapshot_Shutdown() that saves the game and several others cleanup.
Code lines 358 - 374 already exists at the end of the main function.
