### PR TITLE
FTP descend: Fix md5str returning pointer to local variable(NULL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-Clone of dabonetn/linapple-pie 
+Clone of https://github.com/dabonetn/linapple-pie
 
 Fixes FTP not descending into directories.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,3 @@
-# linapple-pie
-Port of linapple2b optimized for front end usage.
+Clone of dabonetn/linapple-pie 
 
-Changes done by Mark Ormond.
-
-Supports mounting and running disks from the command line, and remapping joystick.
-See README-linapple-pie for changes
-
-
-Visit the original linapple page at
-
-http://linapple.sourceforge.net/
-
-and the original Applewin page at
-
-https://github.com/AppleWin
-
-See the README file for more info.
+Fixes FTP not descending into directories.

--- a/src/DiskFTP.cpp
+++ b/src/DiskFTP.cpp
@@ -81,8 +81,11 @@ bool ChooseAnImageFTP(int sx,int sy, char *ftp_dir, int slot, char **filename, b
 		if(!fonts_initialization()) return false;	//if we don't have a fonts, we just can do none
 	char tmpstr[512];
 	char ftpdirpath [MAX_PATH];
-	snprintf(ftpdirpath, MAX_PATH, "%s/%s%s", g_sFTPLocalDir, g_sFTPDirListing, md5str(ftp_dir));	// get path for FTP dir listing
-//	printf("Dir: %s, MD5(dir)=%s\n",ftp_dir,ftpdirpath);
+  char *ftpdirmd5;
+  ftpdirmd5 = md5str(ftp_dir);
+	snprintf(ftpdirpath, MAX_PATH, "%s/%s%s", g_sFTPLocalDir, g_sFTPDirListing, ftpdirmd5);	// get path for FTP dir listing
+	// printf("Dir: %s, MD5(dir)=%s [%p]\n",ftp_dir,ftpdirpath, md5str(ftp_dir));
+  free(ftpdirmd5);
 
 	List<char> files;		// our files
 	List<char> sizes;		// and their sizes (or 'dir' for directories)
@@ -556,6 +559,6 @@ md5str (const char *input)
 
 	for (i=0; i < 16; i++)
 		sprintf (result+2*i, "%02X", digest[i]);
-	return result;
+	return strndup(result, MAX_PATH);
 }
 


### PR DESCRIPTION
Hi,

this is a fix for the ftp not descending into directories. md5str() function returns pointer to local variable which is NULL outside of its scope.
I'm using strndup to copy that string before passing it out and then freeing it to prevent mem leak.

Regards,
Vlado